### PR TITLE
Add options allowing installing a version of sentry newer than 5.1.5.

### DIFF
--- a/DOCUMENTATION.rdoc
+++ b/DOCUMENTATION.rdoc
@@ -17,8 +17,15 @@ This class installs/configures/manages Sentry.
 [*url_prefix*]
       The url prefix sentry is accessible on.  If undefined, it is guessed,
       but when using a proxy you probably want to set this.
+      This should contain the protocol and hostname part; e.g.
+      https://myhost
+[*sub_url*]
+      The sub url sentry is accessible on on the given url_prefix.
+      Start with a slash, end without.
 [*web_port*]
       The port the web server will listen on.
+[*workers*]
+      The number of gunicorn workers to start
 [*install_method*]
       The installation method used to install sentry.
       Choose from:
@@ -27,6 +34,25 @@ This class installs/configures/manages Sentry.
                 https://github.com/uggedal/puppet-module-python
 
       [default] Using virtualenv directly, which will do sudo install
+[*extra_cfg*]
+      Extra configuration at the end of sentry.conf.py
+[*monitor*]
+      Whether to add monitoring of this service
+[*monitor_tool*]
+      Array of tools to monitor with; currently supports nagios.
+[*load_initial_data*]
+      Should initial_data.json be created (default: true).
+      You will have to disable this to install new version of sentry (6.X),
+      because it uses a custom model for User, and this need to be created
+      after migrations have run.
+
+      Caution: setting this to false will ignore the other options:
+               password, salt
+[*requirements_source*]
+      Use customer requirements.txt file. This option allows installing a
+      different version of sentry than 5.1.5, which is the default for this
+      module. To install the latest available version of sentry, just pass
+      a file with just one line "sentry" without specifying the version.
 
 === Requires
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,11 +10,12 @@ class sentry::config (
   $sub_url    = undef,
   $web_port   = 9000,
   $workers    = 3,
-  $extra_cfg  = undef
+  $extra_cfg  = undef,
+  $load_initial_data = true,
+
 ) {
 
     include sentry::install
-
 
     $virtualenv_path = "$path/virtualenv"
 
@@ -28,12 +29,15 @@ class sentry::config (
         notify  => Class['sentry::service'],
     }
 
-    file{"$path/initial_data.json":
+    if $load_initial_data {
+      file{"$path/initial_data.json":
         ensure  => file,
         content => template("sentry/initial_data.json.erb"),
         notify  => Exec['sentry_initiate'],
         owner   => $owner,
-        group   => $group
+        group   => $group,
+        before  => Exec['sentry_initiate'],
+      }
     }
 
     exec{"sentry_initiate":
@@ -42,10 +46,7 @@ class sentry::config (
         group       => $group,
         refreshonly => true,
         logoutput   => on_failure,
-        require     => [
-            File["$path/initial_data.json"],
-            Class["sentry::install"]
-        ],
+        require     => Class["sentry::install"],
         timeout => 0, /* sentry syncdb and migration takes a long time, better make the timeout to be infinite */
     }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,11 +39,6 @@ class sentry::config (
         before  => Exec['sentry_initiate'],
       }
     }
-    else
-    {
-            realize Exec['sentry_initiate']
-    }
-
 
     exec{"sentry_initiate":
         command     => "bash -c 'source $virtualenv_path/bin/activate && sentry --config=$path/sentry.conf.py upgrade --noinput'",

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,7 +26,7 @@ class sentry::config (
         content => template("sentry/sentry.conf.py.erb"),
         owner   => $owner,
         group   => $group,
-        notify  => Class['sentry::service'],
+        notify  => Exec['sentry_initiate'],
     }
 
     if $load_initial_data {
@@ -52,6 +52,7 @@ class sentry::config (
         refreshonly => true,
         logoutput   => on_failure,
         require     => Class["sentry::install"],
+        notify  => Class['sentry::service'],
         timeout => 0, /* sentry syncdb and migration takes a long time, better make the timeout to be infinite */
     }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,6 +39,11 @@ class sentry::config (
         before  => Exec['sentry_initiate'],
       }
     }
+    else
+    {
+            realize Exec['sentry_initiate']
+    }
+
 
     exec{"sentry_initiate":
         command     => "bash -c 'source $virtualenv_path/bin/activate && sentry --config=$path/sentry.conf.py upgrade --noinput'",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,19 @@
 #       Whether to add monitoring of this service
 # [*monitor_tool*]
 #       Array of tools to monitor with; currently supports nagios.
+# [*load_initial_data*]
+#       Should initial_data.json be created (default: true).
+#       You will have to disable this to install new version of sentry (6.X),
+#       because it uses a custom model for User, and this need to be created
+#       after migrations have run.
+#
+#       Caution: setting this to false will ignore the other options:
+#                password, salt
+# [*requirements_source*]
+#       Use customer requirements.txt file. This option allows installing a
+#       different version of sentry than 5.1.5, which is the default for this
+#       module. To install the latest available version of sentry, just pass
+#       a file with just one line "sentry" without specifying the version.
 #
 # === Requires
 #
@@ -68,11 +81,14 @@ class sentry (
   $extra_cfg      = undef,
   $monitor        = true,
   $monitor_tool   = ['nagios'],
+  $load_initial_data = true,
+  $requirements_source = "puppet:///modules/sentry/requirements.txt"
 ) {
 
   class { 'sentry::install':
     method => $install_method,
-    path   => $path
+    path   => $path,
+    requirements_source => $requirements_source,
   }
 
   class { 'sentry::config':
@@ -86,6 +102,7 @@ class sentry (
     web_port   => $web_port,
     workers    => $workers,
     extra_cfg  => $extra_cfg,
+    load_initial_data => $load_initial_data,
   }
 
   class { 'sentry::service':
@@ -97,5 +114,5 @@ class sentry (
       web_port => $web_port
     }
   }
-  
+
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,6 +1,7 @@
 class sentry::install (
   $method = undef,
-  $path   = '/var/sentry'
+  $path   = '/var/sentry',
+  $requirements_source = undef
 ) {
     $virtualenv_path = "${path}/virtualenv"
 
@@ -37,7 +38,8 @@ class sentry::install (
         'venv', 'default': {
             class { "sentry::install::${method}":
                 sentry_path     => $path,
-                virtualenv_path => $virtualenv_path
+                virtualenv_path => $virtualenv_path,
+                requirements_source => $requirements_source,
             }
         }
         default: {

--- a/manifests/install/default.pp
+++ b/manifests/install/default.pp
@@ -1,14 +1,14 @@
 class sentry::install::default(
   $sentry_path,
-  $virtualenv_path
+  $virtualenv_path,
+  $requirements_source
 ) {
     include sentry::python
 
     file{"$sentry_path/requirements.txt":
         ensure => file,
-        source => "puppet:///modules/sentry/requirements.txt"
+        source => $requirements_source
     }
-
 
     exec{"virtualenv":
         command => "virtualenv $virtualenv_path",

--- a/manifests/install/venv.pp
+++ b/manifests/install/venv.pp
@@ -1,6 +1,7 @@
 class sentry::install::venv (
   $sentry_path,
-  $virtualenv_path
+  $virtualenv_path,
+  $requirements_source
 ) {
 
     class { 'python::venv':
@@ -10,6 +11,6 @@ class sentry::install::venv (
 
     python::venv::isolate { $virtualenv_path:
         requirements        => "${sentry_path}/requirements.txt",
-        requirements_source => 'puppet:///modules/sentry/requirements.txt'
+        requirements_source => $requirements_source
     }
 }

--- a/manifests/service/supervisor.pp
+++ b/manifests/service/supervisor.pp
@@ -14,7 +14,7 @@ class sentry::service::supervisor (
       directory   => $sentry_path,
       user        => 'sentry',
       group       => 'sentry',
-      require     => [ Class['sentry::install'] ]
+      require     => [ Exec['sentry_initiate'] ]
   }
 
 }


### PR DESCRIPTION
This allows installing the newest version by passing:

```
    load_initial_data => false,
    requirements_source => '/vagrant/puppet/files/sentry/requirements.txt',
```

to the `sentry` class. The body of the custom `requirements.txt` is:

```
sentry
mysql-python
```

Which downloads the newest sentry. The `mysql-python` is necessary because I use mysql backend instead of sqlite.
